### PR TITLE
Update install.sh for dynamic sha256 checksum verification

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,23 +15,23 @@ apt install -y --no-install-recommends \
 
 case "$(dpkg --print-architecture)" in
 amd64)
-    DART_SHA256=cccd5300faa5a9abce12a5f77586e26350028cea82bb4ff8eeb55641b58a2e1d
     SDK_ARCH="x64"
     ;;
 armhf)
-    DART_SHA256=3a15d42cb1677ac5e50a23045cafe3bf5db2855a5287a3e9019b849fe8477897
     SDK_ARCH="arm"
     ;;
 arm64)
-    DART_SHA256=2c8eeaf0d3da60c4e14beec45ce3b39aca754f71b9fa3fb0c635ee28d6f44708
     SDK_ARCH="arm64"
     ;;
 esac
 
 SDK="dartsdk-linux-${SDK_ARCH}-release.zip"
 URL="$BASEURL/stable/release/${DART_VER}/sdk/$SDK"
+DART_SDK_SHA256="$SDK.sha256sum"
+CHECKSUM_URL="$BASEURL/stable/release/${DART_VER}/sdk/$DART_SDK_SHA256"
 curl -fLO "$URL"
-echo "$DART_SHA256 *$SDK" | sha256sum --check --status --strict -
+curl -fLO "$CHECKSUM_URL"
+cat $DART_SDK_SHA256 | sha256sum --check --status --strict -
 unzip "$SDK"
 mv dart-sdk "$DART_ROOT"
 rm "$SDK"


### PR DESCRIPTION
Updated to retrieve the applicable sha256 checksum file from the dart-archive for dynamically to verify the archive file.